### PR TITLE
feat(default): add github-actions package rule

### DIFF
--- a/presets/default.json
+++ b/presets/default.json
@@ -1,18 +1,24 @@
 {
-	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"description": "Base Renovate configuration for centralized dependency management",
-	"extends": ["config:recommended"],
-	"timezone": "Asia/Tokyo",
-	"labels": ["dependencies"],
-	"semanticCommits": "enabled",
-	"dependencyDashboard": true,
-	"separateMinorPatch": true,
-	"rangeStrategy": "bump",
-	"prConcurrentLimit": 10,
-	"prHourlyLimit": 0,
-	"rebaseWhen": "behind-base-branch",
-	"vulnerabilityAlerts": {
-		"enabled": true,
-		"labels": ["security"]
-	}
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Base Renovate configuration for centralized dependency management",
+  "extends": ["config:recommended"],
+  "timezone": "Asia/Tokyo",
+  "labels": ["dependencies"],
+  "semanticCommits": "enabled",
+  "dependencyDashboard": true,
+  "separateMinorPatch": true,
+  "rangeStrategy": "bump",
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 0,
+  "rebaseWhen": "behind-base-branch",
+  "vulnerabilityAlerts": {"enabled": true, "labels": ["security"]},
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "semanticCommitType": "ci",
+      "semanticCommitScope": "actions",
+      "labels": ["github-actions"]
+    }
+  ]
 }

--- a/presets/default.json
+++ b/presets/default.json
@@ -18,7 +18,7 @@
       "groupName": "GitHub Actions",
       "semanticCommitType": "ci",
       "semanticCommitScope": "actions",
-      "labels": ["github-actions"]
+      "addLabels": ["github-actions"]
     }
   ]
 }


### PR DESCRIPTION
## 概要

デフォルトプリセットに GitHub Actions マネージャーの `packageRules` を追加します。このプリセットを uses している全リポジトリに自動適用されます。

## 変更内容
`presets/default.json` に以下を追加:

- `matchManagers: [github-actions]` でワークフロー内アクションを対象化
- `groupName: GitHub Actions` でまとめて PR 化
- `semanticCommitType: ci` / `semanticCommitScope: actions` でコミットメッセージ自動整形
- `labels: [github-actions]` でラベル付与

## 背景
`codecov/codecov-action@v4` 等が Node.js 20 ベースであり、2026年6月2日以降 Node.js 24 が強制適用される予定。Renovate による自動更新で対応する。