### PR TITLE
chore: add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Internal
+
+- Add `.gitattributes` to enforce LF line endings, preventing spurious "modified" status for `dist/` files on Windows checkouts (`core.autocrlf=true`)
+
 ## [2.2.0] - 2026-02-21
 
 ### Added


### PR DESCRIPTION
## Summary

- Add `.gitattributes` with `* text=auto eol=lf` to enforce LF line endings across the repository.
- Resolves spurious "modified" status on Windows for `dist/` files generated by `build-dist.yml` on Ubuntu (LF) when checked out with `core.autocrlf=true`.

## Background

`dist/` is committed intentionally because:
- `package.json` declares `"bin": "./dist/index.js"` and `"files": ["dist", "presets"]`
- `README.md` documents `pnpm add -g git+https://github.com/...` as an install path (no build step on install)
- `.github/workflows/build-dist.yml` rebuilds and auto-commits `dist/` on `src/**` changes

The CI builder runs on Ubuntu and produces LF, but Windows clones with `core.autocrlf=true` predict CRLF conversion on every touch, leaving `dist/` permanently in a modified state with no actual content diff. This PR pins the EOL policy so all checkouts agree.

## Test plan

- [x] `git status` is clean immediately after `git add --renormalize .` on Windows (`core.autocrlf=true`)
- [ ] `git status` is clean after fresh clone on Windows
- [ ] `git status` is clean after fresh clone on macOS/Linux
- [ ] `build-dist.yml` continues to commit `dist/` without phantom diffs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)