### PR TITLE
chore: upgrade pnpm to v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"typescript": "^6.0.3",
 		"vitest": "^4.1.5"
 	},
-	"packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
+	"packageManager": "pnpm@11.0.8+sha512.4c4097e1dd2d42372c4e7fa5a791ff28fc75a484c7ac192e64b1df0fdef17594ba982f9b4fed9adfb3c757846f565b799b2763fb3733d1de1bcb82cf46684912",
 	"engines": {
 		"node": ">=24.15.0"
 	}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
-ignoredBuiltDependencies:
-  - esbuild
-  - lefthook
+allowBuilds:
+  esbuild: true
+  lefthook: true


### PR DESCRIPTION
## 概要

pnpm を v10 から v11 へアップグレード。

## 変更内容

- \packageManager\ を \pnpm@10.33.0\ から \pnpm@11.0.8\ へ更新
- \pnpm-workspace.yaml\ に \llowBuilds\ を追加（v11 のビルドスクリプト許可の新方式）
- \ignoredBuiltDependencies\ を削除（v10 の旧設定）

## pnpm v11 の破壊的変更

pnpm v11 からビルドスクリプトを持つパッケージは明示的な許可が必要になった。\pnpm approve-builds\ で \sbuild\ と \lefthook\ を承認し、\llowBuilds\ として記録。