### PR TITLE
fix: npm更新をpnpmのrelease age policyに合わせる

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `languages/nodejs` プリセットで npm パッケージ更新に 1 日の minimum release age を適用し、pnpm 11 の supply-chain policy と Renovate PR 作成タイミングを揃えるようにした
+
 ### Internal
 
 - Add `.gitattributes` to enforce LF line endings, preventing spurious "modified" status for `dist/` files on Windows checkouts (`core.autocrlf=true`)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ CLIがプロジェクト構成を自動検出し、最適な `renovate.json` を
 
 | 言語/環境 | プリセット | 説明 |
 |----------|-----------|------|
-| Node.js | `languages/nodejs` | npm/pnpm パッケージ |
+| Node.js | `languages/nodejs` | npm/pnpm パッケージ。npm 更新は公開後 1 日待機 |
 | TypeScript | `languages/typescript` | TypeScript 関連 |
 | Android | `languages/android` | Android (Kotlin/Java, Gradle) |
 | Python | `languages/python` | uv/pyproject.toml |
@@ -179,6 +179,8 @@ renovate-config-init --help
 - マイナー・パッチ更新の分離
 - 脆弱性アラートの有効化
 - タイムゾーン: Asia/Tokyo
+
+`presets/languages/nodejs.json` では npm パッケージ更新に `minimumReleaseAge: "1 day"` と `internalChecksFilter: "strict"` を適用します。pnpm 11 の minimum release age policy と Renovate の PR 作成タイミングを揃え、公開直後のパッケージを含む lockfile で CI が失敗することを抑制します。
 
 ## ライセンス
 

--- a/presets/languages/nodejs.json
+++ b/presets/languages/nodejs.json
@@ -3,6 +3,12 @@
 	"description": "Node.js project configuration for Renovate",
 	"packageRules": [
 		{
+			"description": "Wait for npm releases to mature before raising update branches",
+			"matchDatasources": ["npm"],
+			"minimumReleaseAge": "1 day",
+			"internalChecksFilter": "strict"
+		},
+		{
 			"matchDatasources": ["npm"],
 			"groupName": "Node.js dependencies",
 			"semanticCommitType": "chore",
@@ -31,6 +37,33 @@
 			"matchDepTypes": ["packageManager"],
 			"matchPackageNames": ["pnpm"],
 			"enabled": false
+		},
+		{
+			"description": "Do not require minimum release age for package-manager controlled lockfile maintenance",
+			"matchDatasources": ["npm"],
+			"matchUpdateTypes": ["lockFileMaintenance"],
+			"minimumReleaseAge": null,
+			"prBodyNotes": [
+				"Renovate lock file maintenance delegates updates to the package manager, so confirm the package manager enforces its own minimum release age policy."
+			]
+		},
+		{
+			"description": "Do not require minimum release age for package replacements",
+			"matchDatasources": ["npm"],
+			"matchUpdateTypes": ["replacement"],
+			"minimumReleaseAge": null,
+			"prBodyNotes": [
+				"Renovate replacement updates do not reliably carry release age metadata, so manually confirm the package age before merging."
+			]
+		},
+		{
+			"description": "Do not require minimum release age for package pinning",
+			"matchDatasources": ["npm"],
+			"matchUpdateTypes": ["pin"],
+			"minimumReleaseAge": null,
+			"prBodyNotes": [
+				"Renovate pin updates do not reliably carry release age metadata, so manually confirm the package age before merging."
+			]
 		}
 	],
 	"lockFileMaintenance": {


### PR DESCRIPTION
## 概要

- `languages/nodejs` プリセットに npm datasource 向けの `minimumReleaseAge: "1 day"` と `internalChecksFilter: "strict"` を追加
- `lockFileMaintenance` / `replacement` / `pin` は release age 判定が安定しないため例外化
- README と CHANGELOG に pnpm 11 の minimum release age policy との整合目的を追記

## 背景

Renovate が npm パッケージ公開直後に PR を作成すると、pnpm 11 の supply-chain policy により CI の `pnpm install --frozen-lockfile` が `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` で失敗するケースがある。

テンプレート repository 側で npm 更新を最低 1 日待たせ、Renovate の PR 作成タイミングと pnpm の lockfile 検証タイミングを揃える。

## 影響

`github>scottlz0310/renovate-config//presets/languages/nodejs` を利用する repository では、npm パッケージ更新 PR が公開直後ではなく 1 日経過後に作成される。

## 確認

- `pnpm run validate`
- `pnpm test`
- pre-commit: `biome ci .`, `tsc --noEmit`
- pre-push: `knip --no-config-hints`
