### PR TITLE
chore(release): v2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1] - 2026-05-29
+
 ### Changed
 
 - `languages/nodejs` プリセットで npm パッケージ更新に 1 日の minimum release age を適用し、pnpm 11 の supply-chain policy と Renovate PR 作成タイミングを揃えるようにした
@@ -127,6 +129,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated all documentation to reflect pnpm usage
 - Updated GitHub Actions workflows to use pnpm
 
+[2.2.1]: https://github.com/scottlz0310/renovate-config/releases/tag/v2.2.1
 [2.2.0]: https://github.com/scottlz0310/renovate-config/releases/tag/v2.2.0
 [2.1.0]: https://github.com/scottlz0310/renovate-config/releases/tag/v2.1.0
 [2.0.0]: https://github.com/scottlz0310/renovate-config/releases/tag/v2.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@scottlz0310/renovate-config-init",
-	"version": "2.2.0",
+	"version": "2.2.1",
 	"description": "CLI tool to initialize Renovate configuration with auto-detection",
 	"type": "module",
 	"bin": {


### PR DESCRIPTION
## 概要

- package version を `2.2.1` に更新
- CHANGELOG に `2.2.1` のリリース項目を追加

## リリース内容

- `languages/nodejs` プリセットで npm 更新に 1 日の minimum release age を適用
- `.gitattributes` による LF 行末固定をリリースノートへ反映

## 確認

- `pnpm run check:ci`
- pre-commit: `biome ci .`, `tsc --noEmit`
- pre-push: `knip --no-config-hints` は対象ファイルなしで skip

## リリース手順

この PR を merge 後、`v2.2.1` tag を push して release workflow を実行する。
