### PR TITLE
ci: releaseをnpm Trusted Publishingに移行

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,6 @@ name: Release
         description: "Tag to release (e.g. v2.0.0)."
         required: true
         type: string
-      provenance:
-        description: "Publish with npm provenance (OIDC)."
-        required: false
-        type: boolean
-        default: true
 
 permissions:
   contents: write
@@ -92,28 +87,11 @@ jobs:
         run: pnpm run build
 
       - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         shell: bash
         run: |
           set -euo pipefail
 
-          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
-            echo "Missing secrets.NPM_TOKEN (npm publish token)."
-            exit 1
-          fi
-
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            PROVENANCE="${{ inputs.provenance }}"
-          else
-            PROVENANCE="true"
-          fi
-
-          if [ "$PROVENANCE" = "true" ]; then
-            pnpm publish --provenance --access public --no-git-checks
-          else
-            pnpm publish --access public --no-git-checks
-          fi
+          npm publish --access public --no-git-checks
 
       - name: Create GitHub release (if missing)
         env:


### PR DESCRIPTION
## 概要

- release workflow の publish step を npm Trusted Publishing 用に `npm publish` へ切り替え
- 期限切れ `NPM_TOKEN` への依存と token 存在チェックを削除
- Trusted Publishing では provenance が自動生成されるため、手動 `provenance` input と `--provenance` 指定を削除

## 背景

`v2.2.1` の release workflow は GitHub OIDC token の取得までは成功していたが、`pnpm@11.0.8` の OIDC token exchange が `404` になり、その後期限切れ `NPM_TOKEN` fallback でも npm publish が `404` になっていた。

npm Trusted Publishing は npm CLI 11.5.1 以上を前提にしており、workflow 上では Node 24.16.0 に含まれる npm 11.13.0 が利用できるため、publish のみ npm CLI に寄せる。

## 確認

- `pnpm run check:ci`
- pre-commit: `biome ci .`, `tsc --noEmit`
- pre-push: `knip --no-config-hints`

## リリース再開手順

この PR を merge 後、GitHub Actions の Release workflow を `workflow_dispatch` で `tag=v2.2.1` 指定して再実行する。
