### PR TITLE
ci: npm trusted publishのtoken fallbackを回避

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,6 @@ jobs:
         with:
           node-version: "24.16.0"
           cache: "pnpm"
-          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -91,7 +90,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          npm publish --access public --no-git-checks
+          unset NODE_AUTH_TOKEN
+          unset NPM_CONFIG_USERCONFIG
+
+          npm publish --access public
 
       - name: Create GitHub release (if missing)
         env:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "CLI tool to initialize Renovate configuration with auto-detection",
 	"type": "module",
 	"bin": {
-		"renovate-config-init": "./dist/index.js"
+		"renovate-config-init": "dist/index.js"
 	},
 	"files": [
 		"dist",
@@ -34,7 +34,7 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/scottlz0310/renovate-config.git"
+		"url": "git+https://github.com/scottlz0310/renovate-config.git"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
## 概要

- release workflow の publish step で `NODE_AUTH_TOKEN` と `NPM_CONFIG_USERCONFIG` を明示的に外す
- `actions/setup-node` の `registry-url` 指定を削除し、publish 用 `.npmrc` を生成しない
- npm publish では未対応の `--no-git-checks` を削除
- `npm pkg fix` 相当の package metadata 正規化を反映

## 背景

PR #88 の修正後も `npm publish` が `404` で失敗した。ログでは publish step に `NODE_AUTH_TOKEN` と `NPM_CONFIG_USERCONFIG` が残っており、Trusted Publishing の OIDC ではなく token fallback 側で認証している可能性が高い。

Trusted Publishing では npm CLI が OIDC を使って publish するため、publish step では長寿命 token と setup-node が生成した `.npmrc` に依存しない形にする。

## 確認

- `npm pack --dry-run --json`
- `pnpm run check:ci`
- pre-commit: `biome ci .`, `tsc --noEmit`
- pre-push: `knip --no-config-hints`

## リリース再開手順

この PR を merge 後、`v2.2.1` tag を merge 後の `main` に打ち直して Release workflow を再実行する。
