### PR TITLE
ci: npm publishでprovenanceを明示

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
           unset NODE_AUTH_TOKEN
           unset NPM_CONFIG_USERCONFIG
 
-          npm publish --access public
+          npm publish --provenance --access public
 
       - name: Create GitHub release (if missing)
         env:


### PR DESCRIPTION
## 概要

- npm Trusted Publishing で OIDC provenance を明示的に要求するため、`npm publish --provenance --access public` に変更

## 背景

PR #89 後の Release workflow では token fallback は消えたが、`npm publish --access public` が OIDC publish を開始せず `ENEEDAUTH` になった。

npm provenance publish の経路を明示し、GitHub Actions の `id-token: write` を使った OIDC 交換を確実に発火させる。

## 確認

- `pnpm run check:ci`
- pre-commit: `biome ci .`, `tsc --noEmit`
- pre-push: `knip --no-config-hints`

## リリース再開手順

この PR を merge 後、`v2.2.1` tag を merge 後の `main` に打ち直して Release workflow を再実行する。
