### PR TITLE
fix(schedule): グローバルスケジュールゲートを削除

### DIFF
--- a/presets/options/schedule.json
+++ b/presets/options/schedule.json
@@ -1,7 +1,6 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"description": "Schedule-based preset for controlled update timing",
-	"schedule": ["before 3am on Monday"],
 	"timezone": "Asia/Tokyo",
 	"packageRules": [
 		{


### PR DESCRIPTION
## 問題

`presets/options/schedule.json` のトップレベルに設定されていた `"schedule": ["before 3am on Monday"]` が **グローバルゲート** として機能しており、Renovate が月曜AM3時前以外に実行されるとすべての更新をスキップしていた。

その結果、GitHub App の実行タイミングがこの3時間ウィンドウに当たらない限り、対象リポジトリ（`spotify-ad-recorder` 等の C# リポジトリ）で数ヶ月間 PR が一切作成されない状態になっていた。

## 変更内容

トップレベルの `"schedule"` を削除。

`packageRules` 内の個別スケジュールは維持するため、動作は以下の通り：

| 更新種別 | 変更前 | 変更後 |
|---------|--------|--------|
| major | 月曜AM3時前（グローバルゲートと二重制限） | 月曜AM3時前（packageRule のみ） |
| minor | 月曜AM3時前（同上） | 月曜・木曜AM3時前 |
| patch | 月曜AM3時前（`at any time` がゲートに無効化されていた） | いつでも |
| lockFileMaintenance | 月曜AM3時前 | 月曜AM3時前（維持） |

## 影響範囲

このプリセットを利用しているすべてのリポジトリに適用される。