### PR TITLE
fix(preset): tools/biome の regexManagers を customManagers に移行

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.2] - 2026-06-08
+
+### Fixed
+
+- `tools/biome` プリセットの `regexManagers` を `customManagers` に移行し、Renovate v36+ の新 API に対応 (#104)
+  - `fileMatch` → `managerFilePatterns`（パターンを `/pattern/` 形式に変更）
+
 ## [2.2.1] - 2026-05-29
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@scottlz0310/renovate-config-init",
-	"version": "2.2.1",
+	"version": "2.2.2",
 	"description": "CLI tool to initialize Renovate configuration with auto-detection",
 	"type": "module",
 	"bin": {

--- a/presets/tools/biome.json
+++ b/presets/tools/biome.json
@@ -9,9 +9,10 @@
 			"semanticCommitScope": "biome"
 		}
 	],
-	"regexManagers": [
+	"customManagers": [
 		{
-			"fileMatch": ["(^|/)biome\\.jsonc?$"],
+			"customType": "regex",
+			"managerFilePatterns": ["/(^|/)biome\\.jsonc?$/"],
 			"matchStrings": [
 				"\"\\$schema\":\\s*\"https://biomejs\\.dev/schemas/(?<currentValue>\\d+\\.\\d+\\.\\d+)/schema\\.json\""
 			],


### PR DESCRIPTION
## Summary

- `presets/tools/biome.json` の `regexManagers` を Renovate v36+ 推奨の `customManagers` に移行
- `fileMatch` → `managerFilePatterns`（パターンを `/pattern/` 形式に変更）
- バージョンを `2.2.1` → `2.2.2` にパッチアップ

Closes #104

## 背景

PR #102 の CI 修正作業中に `renovate-config-validator` (renovate v43) が migration 警告を検出。
`regexManagers` / `fileMatch` は非推奨 API のため、現行 API に移行する。

## Test plan

- [x] `pnpm run validate` — renovate-config-validator で全 18 プリセットが警告なしで通過
- [x] `pnpm run knip` — unlisted binaries なし
- [x] `pnpm run check:ci` — tsc / biome / knip / validate / test すべて通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)