### PR TITLE
feat(android): Kotlin toolchain 更新を通常ライブラリ更新から分離する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `languages/android` プリセットで Kotlin / KSP の更新を `Android Kotlin toolchain` グループに分離し、通常の Android ライブラリ更新（`Android minor and patch updates`）と切り離すようにした (#113)
+  - 対象: `org.jetbrains.kotlin.**`（Kotlin plugins・serialization 等）と `com.google.devtools.ksp:**`（KSP）
+  - 旧グループ名 `Kotlin libraries and plugins` を廃止
+
 ## [2.2.2] - 2026-06-08
 
 ### Fixed

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,7 +6,7 @@ pre-commit:
   commands:
     biome-format:
       glob: "*.{ts,js,json,jsonc}"
-      exclude: "presets/**"
+      exclude: "{presets,dist}/**"
       run: pnpm exec biome format --write {staged_files}
       stage_fixed: true
     biome-lint:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,6 +6,7 @@ pre-commit:
   commands:
     biome-format:
       glob: "*.{ts,js,json,jsonc}"
+      exclude: "presets/**"
       run: pnpm exec biome format --write {staged_files}
       stage_fixed: true
     biome-lint:

--- a/presets/languages/android.json
+++ b/presets/languages/android.json
@@ -31,8 +31,11 @@
 			"groupName": "Android Google ecosystem"
 		},
 		{
-			"matchPackageNames": ["org.jetbrains.kotlin.**"],
-			"groupName": "Kotlin libraries and plugins"
+			"matchPackageNames": [
+				"org.jetbrains.kotlin.**",
+				"com.google.devtools.ksp:**"
+			],
+			"groupName": "Android Kotlin toolchain"
 		},
 		{
 			"matchManagers": ["gradle-wrapper"],

--- a/presets/languages/android.json
+++ b/presets/languages/android.json
@@ -33,7 +33,7 @@
 		{
 			"matchPackageNames": [
 				"org.jetbrains.kotlin.**",
-				"com.google.devtools.ksp:**"
+				"com.google.devtools.ksp**"
 			],
 			"groupName": "Android Kotlin toolchain"
 		},


### PR DESCRIPTION
## Summary

- `org.jetbrains.kotlin.**` と `com.google.devtools.ksp:**` を新グループ `Android Kotlin toolchain` に集約し、通常の `Android minor and patch updates` から分離
- 旧グループ名 `Kotlin libraries and plugins` を廃止
- Compose compiler plugin / serialization plugin は `org.jetbrains.kotlin.**` に自然に含まれるため追加対応不要
- Dagger/Hilt (`com.google.dagger.**`) は本グループ対象外（意図通り）

副次対応:
- `lefthook.yml` に `exclude: "presets/**"` を追加（biome 2.5.0 から処理ファイル 0 件時に exit 1 を返す挙動に対応。biome config で既に除外済みの presets/ を lefthook 側でも除外して整合）

Closes #113

## Test plan

- [x] `pnpm test` — 5 tests passed
- [x] `tsc --noEmit` — 型エラーなし
- [x] `knip` — 未使用エクスポートなし
- [x] pre-push hook 通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)