### PR TITLE
feat(presets): enable pnpm packageManager updates in nodejs preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`languages/nodejs` preset**: pnpm `packageManager` 更新を有効化 (#151)
   - `enabled: false` を削除し、通常の Renovate 更新フローに委ねる
-  - `groupName: "pnpm"` を付与して更新 PR を明確にラベリング
+  - `groupName: "pnpm"` を付与（`options/schedule` を後段に `extends` する場合は schedule 側のグループに統合される）
   - `options/automerge` を使うリポジトリでは patch/minor が自動マージされる
   - major は引き続き手動レビュー対象
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`languages/nodejs` preset**: pnpm `packageManager` 更新を有効化 (#151)
+  - `enabled: false` を削除し、通常の Renovate 更新フローに委ねる
+  - `groupName: "pnpm"` を付与して更新 PR を明確にラベリング
+  - `options/automerge` を使うリポジトリでは patch/minor が自動マージされる
+  - major は引き続き手動レビュー対象
+
 - `languages/android` プリセットで Kotlin / KSP の更新を `Android Kotlin toolchain` グループに分離し、通常の Android ライブラリ更新（`Android minor and patch updates`）と切り離すようにした (#113)
   - 対象: `org.jetbrains.kotlin.**`（Kotlin plugins・serialization 等）と `com.google.devtools.ksp:**`（KSP）
   - 旧グループ名 `Kotlin libraries and plugins` を廃止

--- a/presets/languages/nodejs.json
+++ b/presets/languages/nodejs.json
@@ -36,7 +36,9 @@
 		{
 			"matchDepTypes": ["packageManager"],
 			"matchPackageNames": ["pnpm"],
-			"enabled": false
+			"groupName": "pnpm",
+			"semanticCommitType": "chore",
+			"semanticCommitScope": "deps-node"
 		},
 		{
 			"description": "Do not require minimum release age for package-manager controlled lockfile maintenance",


### PR DESCRIPTION
## Summary

- `presets/languages/nodejs.json` の pnpm `packageManager` ルールから `enabled: false` を削除し、通常の Renovate 更新フローを有効化
- `groupName: "pnpm"` と semantic commit 設定を追加して更新 PR を明確にラベリング
- `options/automerge` を使うリポジトリでは patch/minor が自動マージ、major は手動レビュー対象

## 背景

従来は pnpm の `packageManager` 更新が無効化されており、セキュリティアラート経由の更新のみ作成されていた。この設定を使うすべてのリポジトリで pnpm バージョンの追従遅れが発生していた。

## 変更内容

```diff
- {
-   "matchDepTypes": ["packageManager"],
-   "matchPackageNames": ["pnpm"],
-   "enabled": false
- },
+ {
+   "matchDepTypes": ["packageManager"],
+   "matchPackageNames": ["pnpm"],
+   "groupName": "pnpm",
+   "semanticCommitType": "chore",
+   "semanticCommitScope": "deps-node"
+ },
```

## Test plan

- [x] `pnpm run check:ci` 通過（validate / lint / type check / test）
- [x] Renovate バリデーター通過

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)