### PR TITLE
chore(release): v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-06-29
+
 ### Added
 
 - **`languages/nodejs-major` preset** — opt-in preset to enable Node.js major version updates (#146, #150)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated all documentation to reflect pnpm usage
 - Updated GitHub Actions workflows to use pnpm
 
+[Unreleased]: https://github.com/scottlz0310/renovate-config/compare/v2.3.0...HEAD
+[2.3.0]: https://github.com/scottlz0310/renovate-config/compare/v2.2.2...v2.3.0
+[2.2.2]: https://github.com/scottlz0310/renovate-config/compare/v2.2.1...v2.2.2
 [2.2.1]: https://github.com/scottlz0310/renovate-config/releases/tag/v2.2.1
 [2.2.0]: https://github.com/scottlz0310/renovate-config/releases/tag/v2.2.0
 [2.1.0]: https://github.com/scottlz0310/renovate-config/releases/tag/v2.1.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@scottlz0310/renovate-config-init",
-	"version": "2.2.2",
+	"version": "2.3.0",
 	"description": "CLI tool to initialize Renovate configuration with auto-detection",
 	"type": "module",
 	"bin": {


### PR DESCRIPTION
## v2.3.0 リリース準備

### Added
- `languages/nodejs-major` preset — Node.js メジャーバージョン更新を有効化するオプトインプリセット (#146, #150)

### Changed
- `languages/nodejs` preset: pnpm `packageManager` 更新を有効化 (#151)
- `languages/android` preset: Kotlin / KSP を `Android Kotlin toolchain` グループに分離 (#113)

### 作業内容
- `package.json` バージョンを `2.2.2` → `2.3.0` に更新
- `CHANGELOG.md` の `[Unreleased]` を `[2.3.0] - 2026-06-29` に確定

マージ後に `v2.3.0` タグを push して npm 公開ワークフローを起動します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)