### PR TITLE
fix(schedule): lockFileMaintenance の minimumReleaseAge をリセットし stability-days 永久 pending を解消

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `options/schedule` プリセットの `lockFileMaintenance` で `minimumReleaseAge` を `null` にリセット (#176)
+  - 利用側リポジトリがトップレベルに `minimumReleaseAge` を設定していると、lockFileMaintenance PR の `renovate/stability-days` が永遠に pending になる問題を修正
+  - lockFileMaintenance の更新は `releaseTimestamp` を持たないため、Renovate v42+ ではタイムスタンプ不明の更新が「未達」扱いとなり続けることが原因
+
 ## [2.3.0] - 2026-06-29
 
 ### Added

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,7 +6,10 @@ pre-commit:
   commands:
     biome-format:
       glob: "*.{ts,js,json,jsonc}"
-      exclude: "{presets,dist}/**"
+      # 文字列の exclude は正規表現として解釈されるため、glob はリスト形式で指定する
+      exclude:
+        - "presets/**"
+        - "dist/**"
       run: pnpm exec biome format --write {staged_files}
       stage_fixed: true
     biome-lint:

--- a/presets/options/schedule.json
+++ b/presets/options/schedule.json
@@ -20,7 +20,9 @@
 		}
 	],
 	"lockFileMaintenance": {
+		"description": "Reset minimumReleaseAge: lockFileMaintenance upgrades have no releaseTimestamp, so an inherited minimumReleaseAge leaves the stability-days status pending forever",
 		"enabled": true,
-		"schedule": ["before 3am on Monday"]
+		"schedule": ["before 3am on Monday"],
+		"minimumReleaseAge": null
 	}
 }


### PR DESCRIPTION
## 概要

Closes #176

利用側リポジトリがトップレベルに `minimumReleaseAge`（例: arbor の `"3 days"`）を設定していると、`options/schedule` プリセットが有効化する lockFileMaintenance PR の `renovate/stability-days` ステータスが永遠に pending のまま解消されない問題を修正する。

実例: scottlz0310/arbor#182（2026-07-05 作成、9 日以上 pending のまま）

## 原因

- stability-days は各更新の `releaseTimestamp` と `minimumReleaseAge` の比較で判定されるが、lockFileMaintenance はロックファイル全体の再解決であり `releaseTimestamp` を持たない。Renovate v42+ ではタイムスタンプ不明の更新はデフォルトで「未達」扱いとなり、pending が永遠に解消されない
- そもそも lockFileMaintenance はパッケージマネージャに解決を委譲するため、推移的依存に minimumReleaseAge のガードは効いておらず、この pending は保護として機能していない（[公式ドキュメント](https://docs.renovatebot.com/key-concepts/minimum-release-age/)もパッケージマネージャ側での制御を推奨）

参考: [renovate#38115](https://github.com/renovatebot/renovate/discussions/38115), [renovate#10791](https://github.com/renovatebot/renovate/discussions/10791)

## 変更内容

- `presets/options/schedule.json`: `lockFileMaintenance` ブロックに `"minimumReleaseAge": null` を追加し、利用側トップレベル設定の継承を遮断
- `CHANGELOG.md`: Unreleased に追記
- `lefthook.yml`: pre-commit の `exclude` が文字列（正規表現扱い）に glob 記法で書かれていて除外が効かず、presets 配下のファイルをコミットできなかったため、リスト形式に修正（本 PR の作業中に発覚）

## 検証

- `pnpm run validate` — 19 プリセットすべて成功
- pre-push フック（tsc / vitest / knip）通過

## 補足

npm 側のサプライチェーン保護を維持したいリポジトリは、pnpm 10.16+ の `minimumReleaseAge` 設定（解決時ガード、推移的依存にも有効）での補完を推奨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)