### PR TITLE
chore(release): v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-07-16
+
 ### Added
 
 - npm・pnpm・Bun向けのパッケージマネージャプリセットとCLI自動検出を追加 (#185, #187)
@@ -174,7 +176,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated all documentation to reflect pnpm usage
 - Updated GitHub Actions workflows to use pnpm
 
-[Unreleased]: https://github.com/scottlz0310/renovate-config/compare/v2.3.0...HEAD
+[Unreleased]: https://github.com/scottlz0310/renovate-config/compare/v2.4.0...HEAD
+[2.4.0]: https://github.com/scottlz0310/renovate-config/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/scottlz0310/renovate-config/compare/v2.2.2...v2.3.0
 [2.2.2]: https://github.com/scottlz0310/renovate-config/compare/v2.2.1...v2.2.2
 [2.2.1]: https://github.com/scottlz0310/renovate-config/releases/tag/v2.2.1

--- a/biome.json
+++ b/biome.json
@@ -16,7 +16,7 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true
+			"preset": "recommended"
 		}
 	},
 	"javascript": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@scottlz0310/renovate-config-init",
-	"version": "2.3.0",
+	"version": "2.4.0",
 	"description": "CLI tool to initialize Renovate configuration with auto-detection",
 	"type": "module",
 	"bin": {

--- a/test/detector.test.ts
+++ b/test/detector.test.ts
@@ -10,25 +10,28 @@ describe("detector.scanProject", () => {
 		["pnpm", ["pnpm-lock.yaml"]],
 		["bun", ["bun.lock"]],
 		["bun", ["bun.lockb"]],
-	] as const)("detects the %s package manager from its lockfile", async (expectedPreset, lockfiles) => {
-		const dir = await mkdtemp(join(tmpdir(), "renovate-config-init-"));
-		try {
-			for (const lockfile of lockfiles) {
-				await writeFile(join(dir, lockfile), "");
+	] as const)(
+		"detects the %s package manager from its lockfile",
+		async (expectedPreset, lockfiles) => {
+			const dir = await mkdtemp(join(tmpdir(), "renovate-config-init-"));
+			try {
+				for (const lockfile of lockfiles) {
+					await writeFile(join(dir, lockfile), "");
+				}
+
+				const scanResult = await scanProject(dir);
+				const packageManagers = scanResult.root.detectedPresets.filter(
+					(preset) => preset.category === "package-managers",
+				);
+
+				expect(packageManagers).toHaveLength(1);
+				expect(packageManagers[0]?.preset).toBe(expectedPreset);
+				expect(packageManagers[0]?.matchedFiles).toEqual([...lockfiles]);
+			} finally {
+				await rm(dir, { recursive: true, force: true });
 			}
-
-			const scanResult = await scanProject(dir);
-			const packageManagers = scanResult.root.detectedPresets.filter(
-				(preset) => preset.category === "package-managers",
-			);
-
-			expect(packageManagers).toHaveLength(1);
-			expect(packageManagers[0]?.preset).toBe(expectedPreset);
-			expect(packageManagers[0]?.matchedFiles).toEqual([...lockfiles]);
-		} finally {
-			await rm(dir, { recursive: true, force: true });
-		}
-	});
+		},
+	);
 
 	it("detects each package manager when multiple lockfiles coexist", async () => {
 		const dir = await mkdtemp(join(tmpdir(), "renovate-config-init-"));

--- a/test/generator.test.ts
+++ b/test/generator.test.ts
@@ -44,23 +44,22 @@ describe("generator.generateConfig", () => {
 		);
 	});
 
-	it.each([
-		"npm",
-		"pnpm",
-		"bun",
-	])("includes the %s package-manager preset in extends", (packageManager) => {
-		const files = prepareOutputFiles(".", [], {
-			languages: [],
-			packageManagers: [packageManager],
-			tools: [],
-			options: [],
-		});
-		const root = files.find((file) => file.isRoot);
-		if (!root) throw new Error("Root file not found");
-		const config = JSON.parse(root.content) as { extends: string[] };
+	it.each(["npm", "pnpm", "bun"])(
+		"includes the %s package-manager preset in extends",
+		(packageManager) => {
+			const files = prepareOutputFiles(".", [], {
+				languages: [],
+				packageManagers: [packageManager],
+				tools: [],
+				options: [],
+			});
+			const root = files.find((file) => file.isRoot);
+			if (!root) throw new Error("Root file not found");
+			const config = JSON.parse(root.content) as { extends: string[] };
 
-		expect(config.extends).toContain(
-			`github>scottlz0310/renovate-config//presets/package-managers/${packageManager}`,
-		);
-	});
+			expect(config.extends).toContain(
+				`github>scottlz0310/renovate-config//presets/package-managers/${packageManager}`,
+			);
+		},
+	);
 });


### PR DESCRIPTION
## 概要

v2.4.0 のリリース準備として、Issue #189 の対象変更を正式リリース版として確定します。

### 変更内容

- `package.json` のバージョンを `2.3.0` から `2.4.0` に更新
- `CHANGELOG.md` の `Unreleased` の内容を `[2.4.0] - 2026-07-16` として確定
- CHANGELOG の比較リンクを v2.4.0 用に更新

### 検証

- `bun install --frozen-lockfile` 成功
- `bun run tsc:check` 成功
- `bun run knip` 成功
- `bun run validate` 成功
- `bun run test` 成功（3 files / 14 tests）
- `bun run build` 成功
- `bun run check:ci` は既存の Biome lint 問題（deprecated 設定および未整形テスト）で失敗

公開・タグ作成は、この PR のマージ後に実施します。

Refs #189