### PR TITLE
fix(ci): set up Node for npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,11 @@ jobs:
         with:
           bun-version-file: ".bun-version"
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24.18.0"
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 


### PR DESCRIPTION
## 概要

v2.4.0 の Release workflow が npm publish の認証で失敗したため、Trusted Publishing に必要な Node/npm を明示的にセットアップします。

### 原因

Bun 移行で `actions/setup-node` が workflow から削除され、GitHub-hosted runner の npm が npm Trusted Publishing の要件を満たさず、`npm publish --provenance --access public` が `ENEEDAUTH` で失敗しました。

### 変更内容

- `actions/setup-node@v6` を追加
- Node.js `24.18.0` を明示して npm Trusted Publishing を実行

既存の `v2.4.0` タグは変更せず、この PR のマージ後に `workflow_dispatch` で同タグの Release workflow を再実行します。

### 検証

- `bun run check:ci` 成功
- `bun run build` 成功
- `bun install --frozen-lockfile` は既存のタグ workflow で成功
- Release workflow の check/build は成功し、npm publish のみ `ENEEDAUTH` で失敗

Refs #189